### PR TITLE
feat: check for null on message fields

### DIFF
--- a/docs/triggers/README.md
+++ b/docs/triggers/README.md
@@ -25,6 +25,7 @@ The roles that are allowed to use this trigger.
 
 - If no roles are specified, then anyone can use the given trigger.
 - The service does not check for the existence of the roles, so if a role is specified that does not exist, then the trigger will not work for anyone.
+- Specifying the literal of `null` on `content`, `embeds` or `components` will allow content of that field to be carried over from the original message.
 
 ## General Notes
 

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -113,9 +113,9 @@ export function fetchFromGitHub(repo: string, branch: string, path: string) {
 export function resolveMessage(ctx: ComponentContext, target: MessageOptions) {
   const { message: source } = ctx.data;
 
-  if (!target.content && source.content) target.content = '';
-  if (!target.embeds && source.embeds) target.embeds = [];
-  if (!target.components && source.components) target.components = [];
+  if (!('content' in target) && target.content !== null && source.content) target.content = '';
+  if (!('embeds' in target) && target.embeds !== null && source.embeds) target.embeds = [];
+  if (!('components' in target) && target.components !== null && source.components) target.components = [];
 
   const errors: string[] = [];
 


### PR DESCRIPTION
Check for the literal of `null` on message fields (`content`, `embeds` and `components`) allowing their data be carried over from the parent message. _The message data sent over will remain as the literal of null, as Discord has intended._

https://user-images.githubusercontent.com/8607699/204325532-bd7c53a1-9bd6-4f6f-a2f3-97c5b0105bed.mp4

Demo content: https://github.com/sudojunior/test-response/tree/e32aa09f92ac67fe704f4f8548019cb890beb338/router