### PR TITLE
feat: dud component

### DIFF
--- a/docs/triggers/btn-role.md
+++ b/docs/triggers/btn-role.md
@@ -1,10 +1,29 @@
-## Button Role - `btn-role`
+# Button Role - `btn-role`
 
 This trigger is used to toggle a role on a user when a button is clicked.
 
-### Format
+## Format
 
 > `btn-role:<role>[&<role>...]`
 
 - `role` - The role to toggle on the user.
 - `&role...` - The roles that are allowed to use this trigger.
+
+## Example
+
+```yaml
+# Path: example/query.yaml
+content: "Click the button to toggle the role."
+components:
+  - type: 1
+    components:
+      # toggle 123456789012345678
+      - type: 2
+        custom_id: "btn-role:123456789012345678"
+        label: "Toggle Role 1"
+        style: 1
+      # toggle 123456789012345678 requiring 234567890123456789
+      - type: 2
+        custom_id: "btn-role:123456789012345678&234567890123456789"
+        label: "Toggle Role 2"
+        style: 1

--- a/docs/triggers/dud.md
+++ b/docs/triggers/dud.md
@@ -1,0 +1,47 @@
+# Any Component `dud`
+
+This trigger is used to do nothing when a button is clicked.
+
+## Format
+
+> `dud[:**][?debug]`
+
+- `:**` - (Optional) The Unique ID of the component.
+- `?debug` - (Optional) The debug flag.
+
+## Example
+
+```yaml
+# Path: example/query.yaml
+content: "Click the button to do nothing."
+components:
+  - type: 1
+    components:
+      # do nothing
+      - type: 2
+        custom_id: "dud"
+        label: "Do Nothing"
+        style: 1
+      # do nothing with debug
+      - type: 2
+        custom_id: "dud?debug"
+        label: "Do Nothing (Debug)"
+        style: 1
+      # do nothing with unique id
+      - type: 2
+        custom_id: "dud:123456789012345678"
+        label: "Do Nothing (Unique ID)"
+        style: 1
+      # do nothing with unique id and debug
+      - type: 2
+        custom_id: "dud:123456789012345678?debug"
+        label: "Do Nothing (Unique ID & Debug)"
+        style: 1
+```
+
+## Notes
+
+- This trigger is used to do nothing when a button is clicked, by default.
+- Adding `?debug` to the end of the `custom_id` will enable debug mode.
+- *It is required to add a unique id to the `custom_id` if you want to use multiple `dud` triggers in the same message. Add any string of numbers and letters after the `:` to make the `custom_id` unique.*
+- *Useful in demos / mock-ups for users (with or without debug mode).*

--- a/docs/triggers/pick-msg.md
+++ b/docs/triggers/pick-msg.md
@@ -1,18 +1,16 @@
-
-
-### Select Message - `pick-msg`
+# Select Message - `pick-msg`
 
 This trigger is used to pick a response from a list of options.
 
 > Only supports GitHub at the moment, but can be extended to support other services.
 
-#### Format (`~.custom_id`)
+## Format (`~.custom_id`)
 
 > `pick-msg[&<role>...]`
 
 - `&role...` - (Optional) The roles that are allowed to use this trigger.
 
-#### Format (`~.options.*.value`)
+## Format (`~.options.*.value`)
 
 > `<owner/repo>@<branch>#<path/to/file.yaml>`
 
@@ -20,7 +18,7 @@ This trigger is used to pick a response from a list of options.
 - `branch` - The branch of the repository to fetch the file from.
 - `path/to/file.yaml` - The path to the file within the repository.
 
-#### Example
+## Example
 
 ```yaml
 # Path: example/query.yaml

--- a/src/components/dud.ts
+++ b/src/components/dud.ts
@@ -1,0 +1,86 @@
+// #region Imports
+
+// Node
+import { parse as qsParse } from 'querystring';
+
+// Packages
+import { ComponentActionRow, ComponentSelectMenu, ComponentType, MessageOptions } from 'slash-create';
+import { findComponent, findComponentPosition } from '../util/common';
+
+// Local
+import { PatternComponent } from '../util/PatternComponent';
+
+// #endregion
+
+function deconstructInput(input: string) {
+  const [, identifier, stringOptions] = input.split(/[:?]/g);
+
+  const parsedOptions = qsParse(stringOptions);
+
+  return {
+    identifier,
+    debug: ['', 'true', '1'].includes(parsedOptions.debug?.toString().toLowerCase())
+  };
+}
+
+export default new PatternComponent('dud')
+  .withPattern(/^dud(?::?[$&\w]*)?(?:\?[\w_]*)?/)
+  .withLogHook((ctx) => ({
+    ...deconstructInput(ctx.customID),
+    type: ComponentType[ctx.componentType],
+    ...(ctx.values && { values: ctx.values })
+  }))
+  .withMethod(async (ctx) => {
+    const { identifier, debug } = deconstructInput(ctx.customID);
+    const [row, column] = findComponentPosition(ctx.message.components, ctx.customID);
+    const component = findComponent(ctx.message.components, ctx.customID);
+
+    let response: MessageOptions;
+
+    if (debug) {
+      response = {
+        embeds: [
+          {
+            title: `Debugging for \`${identifier}\` on ${ComponentType[component.type]}`,
+            description: [
+              `**Row**: ${row} (Max 5)`,
+              `**Column**: ${column} (Max ${ctx.componentType === ComponentType.BUTTON ? 5 : 1})`,
+              `**Custom ID:** \`${component.custom_id}\`\n`
+            ].join('\n'),
+            fields: []
+          }
+        ]
+      };
+
+      const resolvedData = ctx.values.map((struct) => {
+        const { emoji, label, value, description } = (component as ComponentSelectMenu).options.find(
+          (option) => option.value === struct
+        );
+
+        const emojiString = (emoji?.id ? `<:${emoji.name}:${emoji.id}>` : emoji?.name) ?? '';
+        const collection = [ctx.channels, ctx.users, ctx.roles].find((list) => list.has(struct));
+        const display: string = collection?.get(struct)?.toString() ?? `${label} (${value})`.trim();
+        return `${emojiString} ${display} ${description ? '\n> ' + description : ''}`.trim();
+      });
+
+      // if data is available, certain to be a select menu of some kind
+      if (resolvedData.length > 0) {
+        const select = component as ComponentSelectMenu;
+
+        response.embeds[0].fields.push({
+          name: 'Resolved Data',
+          value: resolvedData.join('\n') || 'None'
+        });
+
+        response.embeds[0].description += [
+          select.min_values && `**Min Values:** ${select.min_values}`,
+          select.max_values && `**Max Values:** ${select.max_values}`,
+          select.placeholder && `**Placeholder:** ${select.placeholder}`
+        ]
+          .filter(Boolean)
+          .join('\n');
+      }
+    }
+
+    return response ? { ...response, ephemeral: true } : null;
+  });

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,6 +6,7 @@ import { SlashCreator } from 'slash-create';
 // Local - Components
 import btnRole from './btn-role';
 import btnMsg from './btn-msg';
+import dud from './dud';
 import pickRole from './pick-role';
 import pickMsg from './pick-msg';
 
@@ -14,7 +15,7 @@ import componentInteractionEvent from '../events/componentInteraction';
 
 // #endregion
 
-const components = [btnRole, pickRole, btnMsg, pickMsg];
+const components = [btnRole, pickRole, btnMsg, pickMsg, dud];
 
 export function registerListener(creator: SlashCreator) {
   components.forEach((component) => component.register());

--- a/src/events/componentInteraction.ts
+++ b/src/events/componentInteraction.ts
@@ -17,7 +17,7 @@ export default async (ctx: ComponentContext) => {
   }
 
   const trigger = PatternComponent.registeredPatterns.find(
-    (instance) => ctx.componentType === instance.type && instance.pattern.test(ctx.customID)
+    (instance) => (instance.type ? ctx.componentType === instance.type : true) && instance.pattern.test(ctx.customID)
   );
 
   const holder = `${ctx.guildID ? `${ctx.guildID}/` : ''}${ctx.channelID}/${ctx.message.id}`;
@@ -31,6 +31,7 @@ export default async (ctx: ComponentContext) => {
       const result = await trigger.method(ctx);
 
       if (!result) {
+        ctx.acknowledge();
         return;
       }
 

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -41,7 +41,6 @@ export function findComponentPosition(components: AnyComponent[], id: string): [
       const component = row.components[j];
       if ('url' in component) return;
       if (component.type === ComponentType.TEXT_INPUT) return;
-      if (![ComponentType.BUTTON, ComponentType.STRING_SELECT].includes(component.type)) return;
       if (component.custom_id.startsWith(id)) {
         return [i, j];
       }


### PR DESCRIPTION
Closes #6 

- `dud:alpha` - Standard behaviour
- `dud:bravo?debug` - Debug interaction context for selection and any resolved data available to it.

**Any message-based component can be used with this, greatly increasing visible use of components (even if they don't affect the outcome - other than the data they may provide).**