### PR TITLE
patch: remove default `null` behaviour

### DIFF
--- a/docs/triggers/README.md
+++ b/docs/triggers/README.md
@@ -25,7 +25,9 @@ The roles that are allowed to use this trigger.
 
 - If no roles are specified, then anyone can use the given trigger.
 - The service does not check for the existence of the roles, so if a role is specified that does not exist, then the trigger will not work for anyone.
-- Specifying the literal of `null` on `content`, `embeds` or `components` will allow content of that field to be carried over from the original message.
+- Not specifying `content`, `embeds` or `components` will allow content of that field to be carried over from the original message.
+- Specifying the literal of `null` or their empty default on the aforementioned fields, will reset the field.
+  > *This change was made at some point after Feb 10th, which corrected faulty behaviour on Discord's end. - [discord/discord-api-docs#5860](https://github.com/discord/discord-api-docs/issues/5860)*
 
 ## General Notes
 

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -112,10 +112,6 @@ export function fetchFromGitHub(repo: string, branch: string, path: string) {
 export function resolveMessage(ctx: ComponentContext, target: MessageOptions) {
   const { message: source } = ctx.data;
 
-  if (!('content' in target) && target.content !== null && source.content) target.content = '';
-  if (!('embeds' in target) && target.embeds !== null && source.embeds) target.embeds = [];
-  if (!('components' in target) && target.components !== null && source.components) target.components = [];
-
   const errors: string[] = [];
 
   for (const index in target.components) {


### PR DESCRIPTION
This accounts for the changes made to Discord's infrastructure with https://github.com/discord/discord-api-docs/issues/5860 which _corrects_ the nullable field behaviour introduced with https://github.com/TinkerStorm/turbo-eureka/commit/e325023cea58086420b9d0ff9af6ec8fac03a5c0.

The only critical failures to be known to me is with [this community's onboarding router](https://github.com/TinkerStorm/community/tree/main/router) with `~/archive` and `~/city-hall/creative-storm` for their intentions to retain component state across messages.